### PR TITLE
Added `Terminal` component

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "terminal-froggy"
+name = "quack-n-hack"
 version = "0.1.0"
 edition = "2021"
 
@@ -18,3 +18,4 @@ gloo-net = { version = "0.2", features = ["http"] }
 wasm-bindgen = { version = "0.2" }
 console_log = { version = "1"}
 console_error_panic_hook = { version = "0.1"}
+js-sys = "0.3.63"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# Terminal Froggy
+# Quack 'n Hack: Unix for Kids

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link data-trunk rel="rust" data-wasm-opt="z" />
     <link data-trunk rel="icon" type="image/ico" href="/public/favicon.ico" />
     <link data-trunk rel="css" href="/style/output.css" />
-    <title>Leptos • Counter with Tailwind</title>
+    <title>Quack 'n Hack: Unix for Kids</title>
 </head>
 
 <body></body>

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,6 +12,7 @@ pub fn App(cx: Scope) -> impl IntoView {
         cx,
         <Stylesheet id="leptos" href="/pkg/tailwind.css"/>
         <Link rel="shortcut icon" type_="image/ico" href="/favicon.ico"/>
+        <Script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js" />
         <Header />
         <Router>
             <Routes>

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,2 +1,3 @@
 pub mod header;
 pub mod page_wrapper;
+pub mod terminal;

--- a/src/components/header.rs
+++ b/src/components/header.rs
@@ -6,7 +6,7 @@ pub fn Header(cx: Scope) -> impl IntoView {
         cx,
         <div class="bg-matte-black text-white">
             <div class="lg:max-w-header mx-auto px-5 py-5">
-                <h1 class="text-2xl">"$ Terminal"<span class="text-mint-green">"Froggy"</span></h1>
+                <h1 class="text-2xl">"$ "<span class="text-pastel-yellow">"Quack"</span>" 'n Hack: Unix for Kids"</h1>
                 <div id="divider" class="h-0.5 mt-3 bg-white opacity-20 mx-auto" />
             </div>
         </div>

--- a/src/components/terminal.rs
+++ b/src/components/terminal.rs
@@ -1,0 +1,95 @@
+use crate::types::terminal_content::TerminalContent;
+use leptos::{ev::SubmitEvent, html::Input, *};
+use std::time::Duration;
+
+#[component]
+pub fn Terminal<F>(
+    cx: Scope,
+    // TODO - Tech Debt: Find a way to pass terminal in as mut
+    terminal: TerminalContent,
+    /// Callback used to signal when the terminal instance is completed
+    complete_callback: F,
+) -> impl IntoView
+where
+    F: Fn(bool) + 'static,
+{
+    // Variables
+    let mut terminal = terminal;
+    let title = terminal.create_title(cx);
+
+    // References
+    let terminal_input_ref: NodeRef<Input> = create_node_ref(cx);
+
+    // Signals
+    let (show_error, set_show_error) = create_signal(cx, false);
+    let (disable_input, set_disable_input) = create_signal(cx, false);
+    let (terminal_content, set_terminal_content) = create_signal(cx, Vec::new());
+
+    // Handlers
+    let on_submit = move |ev: SubmitEvent| {
+        ev.prevent_default();
+
+        let input = terminal_input_ref().expect("<input> to exist").value();
+
+        match terminal.check_answer(input.trim()) {
+            Ok(output) => {
+                let mut new_content = terminal_content();
+                new_content.push(output);
+                set_terminal_content.set(new_content);
+
+                terminal.next();
+            }
+            Err(_) => {
+                if !show_error() {
+                    set_show_error(true);
+                }
+            }
+        }
+
+        if terminal.check_finished() {
+            set_disable_input(true);
+            complete_callback(true);
+        }
+
+        terminal_input_ref()
+            .expect("<input> to exist")
+            .set_value("");
+    };
+
+    // Effects
+    create_effect(cx, move |_| {
+        if show_error() {
+            set_timeout(move || set_show_error(false), Duration::new(1, 0));
+        }
+    });
+
+    // Classes
+    let body_styling = "bg-terminal-dark-blue text-white border-2 border-pastel-purple h-96 overflow-scroll animate-wiggle";
+
+    view! {
+        cx,
+        <div
+            class=move || if show_error() {format!("{} animate-shake", body_styling)} else {body_styling.to_string()}
+            on:click=move |_| terminal_input_ref().expect("<input> to exist").focus().expect("<input> to exist")
+        >
+            <div class="mx-auto px-5 py-5">
+                <form on:submit=on_submit>
+                    <p>{title}</p>
+
+                    {terminal_content}
+
+                    <p>
+                        "[root@"<span class="text-pastel-blue">"quack"</span>" ~]$ "
+                            <input
+                                class="outline-none bg-transparent"
+                                type="text"
+                                node_ref=terminal_input_ref
+                                disabled=disable_input()
+                                autofocus
+                            />
+                    </p>
+                </form>
+            </div>
+        </div>
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod components;
 mod pages;
+mod types;
 
 use app::*;
 use leptos::*;

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -1,12 +1,44 @@
-use leptos::*;
-
 use crate::components::page_wrapper::*;
+use crate::components::terminal::*;
+use crate::types::terminal_content::TerminalContent;
+use leptos::*;
 
 #[component]
 pub fn Home(cx: Scope) -> impl IntoView {
+    // Signals
+    let (complete, set_complete) = create_signal(cx, false);
+    // TODO - Temporary: Parse this from a file instead of hard-coding
+    let terminal = TerminalContent::new("lesson-01_baby-steps", vec![
+        (String::from("ls"), view! {cx, 
+            <div>
+                <p><span class="text-pastel-blue">"❯ "</span>"ls"</p>
+                <div class="flex justify-around">
+                    <span>"Waddle.duck"</span>
+                    <span>"Ducky.duck"</span>
+                    <span>"Pippin.duck"</span>
+                    <a class="cursor-pointer"><span class="text-pastel-yellow">"Quacky.duck"</span></a>
+                    <span>"Bubbles.duck"</span>
+                </div>
+            </div>
+        }.into_any()),
+        (String::from("help"), view! {cx, <p><span class="text-pastel-blue">"❯ "</span>"help"</p>}.into_any()),
+    ]);
+
+    // Effects
+    create_effect(cx, move |_| {
+        complete();
+        let _ = js_sys::eval(
+            "window.confetti({
+                    particleCount: 200,
+                    spread: 100,
+                    origin: { y: 0.6 }
+                });",
+        );
+    });
+
     view! { cx,
         <PageWrapper>
-            <p>"Hello World"</p>
+            <Terminal terminal={terminal} complete_callback={set_complete} />
         </PageWrapper>
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,1 @@
+pub mod terminal_content;

--- a/src/types/terminal_content.rs
+++ b/src/types/terminal_content.rs
@@ -1,0 +1,52 @@
+use crate::{html::AnyElement, view, HtmlElement, IntoView, Scope};
+
+#[derive(Clone)]
+pub struct TerminalContent {
+    pub progress: usize,
+    pub title: String,
+    pub answers: Vec<(String, HtmlElement<AnyElement>)>,
+}
+
+impl TerminalContent {
+    pub fn new(title: &str, answers: Vec<(String, HtmlElement<AnyElement>)>) -> Self {
+        TerminalContent {
+            progress: 0,
+            title: title.to_string(),
+            answers,
+        }
+    }
+
+    pub fn create_title(&self, cx: Scope) -> impl IntoView {
+        view! {cx,
+            <p>
+                <span class="text-pastel-blue">"❯ "</span>{self.title.clone()}
+            </p>
+        }
+    }
+
+    pub fn check_answer(&mut self, input: &str) -> Result<HtmlElement<AnyElement>, ()> {
+        let output = self
+            .answers
+            .get(self.progress)
+            .expect("self.progress to never provide an out of bounds value");
+
+        if output.0 == input {
+            Ok(output.1.clone())
+        } else {
+            Err(())
+        }
+    }
+
+    pub fn next(&mut self) -> Option<()> {
+        if self.check_finished() {
+            return None;
+        }
+
+        self.progress += 1;
+        Some(())
+    }
+
+    pub fn check_finished(&self) -> bool {
+        self.progress == self.answers.len()
+    }
+}

--- a/style/output.css
+++ b/style/output.css
@@ -516,6 +516,10 @@ video {
   --tw-backdrop-sepia:  ;
 }
 
+.static {
+  position: static;
+}
+
 .mx-auto {
   margin-left: auto;
   margin-right: auto;
@@ -529,12 +533,20 @@ video {
   margin-top: 0.75rem;
 }
 
+.flex {
+  display: flex;
+}
+
 .h-0 {
   height: 0px;
 }
 
 .h-0\.5 {
   height: 0.125rem;
+}
+
+.h-96 {
+  height: 24rem;
 }
 
 .h-screen {
@@ -545,9 +557,69 @@ video {
   width: 100%;
 }
 
+@keyframes shake {
+  0% {
+    transform: translateX(0%);
+  }
+
+  20% {
+    transform: translateX(-2%);
+  }
+
+  40% {
+    transform: translateX(2%);
+  }
+
+  60% {
+    transform: translateX(-2%);
+  }
+
+  80% {
+    transform: translateX(2%);
+  }
+
+  100% {
+    transform: translateX(0%);
+  }
+}
+
+.animate-shake {
+  animation: shake 1s ease-in-out;
+}
+
+.cursor-pointer {
+  cursor: pointer;
+}
+
+.justify-around {
+  justify-content: space-around;
+}
+
+.overflow-scroll {
+  overflow: scroll;
+}
+
+.border-2 {
+  border-width: 2px;
+}
+
+.border-pastel-purple {
+  --tw-border-opacity: 1;
+  border-color: rgb(213 190 232 / var(--tw-border-opacity));
+}
+
 .bg-matte-black {
   --tw-bg-opacity: 1;
   background-color: rgb(31 31 31 / var(--tw-bg-opacity));
+}
+
+.bg-terminal-dark-blue {
+  --tw-bg-opacity: 1;
+  background-color: rgb(30 30 46 / var(--tw-bg-opacity));
+}
+
+.bg-transparent {
+  background-color: transparent;
 }
 
 .bg-white {
@@ -574,9 +646,14 @@ video {
   line-height: 2rem;
 }
 
-.text-mint-green {
+.text-pastel-blue {
   --tw-text-opacity: 1;
-  color: rgb(176 205 130 / var(--tw-text-opacity));
+  color: rgb(178 216 216 / var(--tw-text-opacity));
+}
+
+.text-pastel-yellow {
+  --tw-text-opacity: 1;
+  color: rgb(255 248 165 / var(--tw-text-opacity));
 }
 
 .text-white {
@@ -586,6 +663,11 @@ video {
 
 .opacity-20 {
   opacity: 0.2;
+}
+
+.outline-none {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
 }
 
 @media (min-width: 1024px) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,12 +7,30 @@ module.exports = {
         extend: {
             colors: {
                 "matte-black": "#1F1F1F",
-                "mint-green": "#B0CD82",
+                "pastel-green": "#A2D9B1",
+                "pastel-blue": "#B2D8D8",
+                "pastel-yellow": "#FFF8A5",
+                "pastel-purple": "#D5BEE8",
+                "pastel-red": "#FCC9B9",
                 "terminal-gray": "#2C2C2C",
+                "terminal-dark-blue": "#1E1E2E",
             },
             maxWidth: {
                 "header": "1920px",
                 "content": "1080px",
+            },
+            keyframes: {
+                shake: {
+                    "0%": { transform: "translateX(0%)" },
+                    "20%": { transform: "translateX(-2%)" },
+                    "40%": { transform: "translateX(2%)" },
+                    "60%": { transform: "translateX(-2%)" },
+                    "80%": { transform: "translateX(2%)" },
+                    "100%": { transform: "translateX(0%)" },
+                }
+            },
+            animation: {
+                shake: "shake 1s ease-in-out",
             }
         },
     },


### PR DESCRIPTION
## Changes
- Added `Terminal` component
- Added `TerminalContent` struct
- Added script for confetti https://github.com/catdad/canvas-confetti#readme
- Added `sys_js` to run JS confetti script
- Changed project name from "TerminalFroggy" to "Quack 'n Hack: Unix for Kids"
- Added Tailwind animation "Shake" - used for when an incorrect answer is typed in terminal

## Notes
- To use the terminal in this PR, the valid sequence is `ls` -> `help`

## Images
<img width="1477" alt="image" src="https://github.com/BrookJeynes/quack-n-hack/assets/25432120/14f7ddeb-dfce-4d19-b44f-e1acac133737">  

**Figure: New Terminal component**
