### PR TITLE
Added `InstructionsPanel` component

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ leptos_meta = { version = "0.2", features = ["csr"] }
 leptos_router = { version = "0.2", features = ["csr"]  }
 log = "0.4"
 gloo-net = { version = "0.2", features = ["http"] }
-
-
-# dependecies for client (enable when csr or hydrate set)
 wasm-bindgen = { version = "0.2" }
 console_log = { version = "1"}
 console_error_panic_hook = { version = "0.1"}

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,3 +1,5 @@
 pub mod header;
+pub mod instructions_panel;
 pub mod page_wrapper;
 pub mod terminal;
+pub mod tooltip;

--- a/src/components/instructions_panel.rs
+++ b/src/components/instructions_panel.rs
@@ -10,6 +10,7 @@ pub fn InstructionsPanel<F, V>(
     level: ReadSignal<usize>,
 ) -> impl IntoView
 where
+    // TODO - Research: Is there a way to coerce these into a single generic?
     F: Fn() + 'static,
     V: Fn() + 'static,
 {
@@ -26,21 +27,27 @@ where
             </div>
 
             <div class="flex flex-row justify-around items-center px-4 py-2">
-                <svg
-                    class="w-7 fill-white cursor-pointer" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"
-                    on:click=move |_| decrement_level_callback()
-                >
-                    <path d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.2 288 416 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-306.7 0L214.6 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"/>
-                </svg>
+                <button on:click=move |_| decrement_level_callback()>
+                    <svg
+                        class="w-7 fill-white cursor-pointer"
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 448 512"
+                    >
+                        <path d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.2 288 416 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-306.7 0L214.6 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"/>
+                    </svg>
+                </button>
 
                 <span>"Level "{level}</span>
 
-                <svg
-                    class="w-7 fill-white cursor-pointer" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"
-                    on:click=move |_| increment_level_callback()
-                >
-                    <path d="M438.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L338.8 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l306.7 0L233.4 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"/>
-                </svg>
+                <button on:click=move |_| increment_level_callback()>
+                    <svg
+                        class="w-7 fill-white cursor-pointer"
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 448 512"
+                    >
+                        <path d="M438.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L338.8 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l306.7 0L233.4 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"/>
+                    </svg>
+                </button>
             </div>
         </div>
     }

--- a/src/components/instructions_panel.rs
+++ b/src/components/instructions_panel.rs
@@ -1,0 +1,47 @@
+use leptos::*;
+
+#[component]
+pub fn InstructionsPanel<F, V>(
+    cx: Scope,
+    children: Children,
+    #[prop(optional)] class: String,
+    increment_level_callback: F,
+    decrement_level_callback: V,
+    level: ReadSignal<usize>,
+) -> impl IntoView
+where
+    F: Fn() + 'static,
+    V: Fn() + 'static,
+{
+    view! {
+        cx,
+        <div
+            class=format!("{} {} {}",
+                "bg-terminal-dark-blue text-white border-2 border-pastel-purple",
+                "h-96 md:h-[30rem] flex flex-col justify-between",
+                class)
+        >
+            <div class="overflow-scroll mx-auto p-5">
+                {children(cx)}
+            </div>
+
+            <div class="flex flex-row justify-around items-center px-4 py-2">
+                <svg
+                    class="w-7 fill-white cursor-pointer" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"
+                    on:click=move |_| decrement_level_callback()
+                >
+                    <path d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.2 288 416 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-306.7 0L214.6 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"/>
+                </svg>
+
+                <span>"Level "{level}</span>
+
+                <svg
+                    class="w-7 fill-white cursor-pointer" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"
+                    on:click=move |_| increment_level_callback()
+                >
+                    <path d="M438.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L338.8 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l306.7 0L233.4 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"/>
+                </svg>
+            </div>
+        </div>
+    }
+}

--- a/src/components/page_wrapper.rs
+++ b/src/components/page_wrapper.rs
@@ -4,8 +4,8 @@ use leptos::*;
 pub fn PageWrapper(cx: Scope, children: Children) -> impl IntoView {
     view! {
         cx,
-        <div class="h-screen bg-matte-black text-white">
-            <div class="pt-20 mb-10 mx-auto px-5 w-full lg:px-0 lg:max-w-content">
+        <div class="h-full min-h-screen bg-matte-black text-white">
+            <div class="pt-5 md:pt-20 pb-10 mx-auto px-5 w-full lg:px-0 lg:max-w-content">
                 {children(cx)}
             </div>
         </div>

--- a/src/components/terminal.rs
+++ b/src/components/terminal.rs
@@ -2,7 +2,7 @@ use crate::types::terminal_content::TerminalContent;
 use leptos::{ev::SubmitEvent, html::Input, *};
 use std::time::Duration;
 
-// TODO - Tech Debt: Find a way to not allow the whole 
+// TODO - Tech Debt: Find a way to not allow the whole
 // component but rather the single closure
 #[allow(clippy::redundant_closure)]
 #[component]

--- a/src/components/terminal.rs
+++ b/src/components/terminal.rs
@@ -1,4 +1,4 @@
-use crate::types::terminal_content::TerminalContent;
+use crate::types::level::Level;
 use leptos::{ev::SubmitEvent, html::Input, *};
 use std::time::Duration;
 
@@ -8,7 +8,7 @@ use std::time::Duration;
 #[component]
 pub fn Terminal<F>(
     cx: Scope,
-    terminal: TerminalContent,
+    terminal: Signal<Level>,
     /// Callback used to signal when the terminal instance is completed
     complete_callback: F,
     #[prop(optional)] class: String,
@@ -17,8 +17,7 @@ where
     F: Fn(bool) + 'static,
 {
     // Variables
-    let mut terminal = terminal;
-    let title = terminal.create_title(cx);
+    let title = move || terminal().content.create_title(cx);
 
     // References
     let terminal_input_ref: NodeRef<Input> = create_node_ref(cx);
@@ -34,11 +33,11 @@ where
 
         let input = terminal_input_ref().expect("<input> to exist").value();
 
-        match terminal.check_answer(input.trim()) {
+        match terminal().content.check_answer(input.trim()) {
             Ok(output) => {
                 set_terminal_content.update(|content| content.push(output));
 
-                if terminal.next().is_none() {
+                if terminal().content.next().is_none() {
                     set_disable_input(true);
                     complete_callback(true);
                 }
@@ -75,7 +74,7 @@ where
                 <form on:submit=on_submit>
                     <p>{title}</p>
 
-                    {terminal_content}
+                    {move || terminal_content}
 
                     <p>
                         "[root@"<span class="text-pastel-blue">"quack"</span>" ~]$ "
@@ -83,7 +82,6 @@ where
                                 class="outline-none bg-transparent"
                                 type="text"
                                 node_ref=terminal_input_ref
-                                // Closure not redundant - required for state updates
                                 disabled=move || disable_input()
                                 autofocus
                             />

--- a/src/components/terminal.rs
+++ b/src/components/terminal.rs
@@ -2,15 +2,13 @@ use crate::types::level::Level;
 use leptos::{ev::SubmitEvent, html::Input, *};
 use std::time::Duration;
 
-// TODO - Tech Debt: Find a way to not allow the whole
-// component but rather the single closure
+// Leptos makes great use of "redundant closures" to update state.
 #[allow(clippy::redundant_closure)]
 #[component]
 pub fn Terminal<F>(
     cx: Scope,
     terminal: Level,
-    /// Callback used to signal when the terminal instance is completed
-    complete_callback: F,
+    complete_level_callback: F,
     #[prop(optional)] class: String,
 ) -> impl IntoView
 where
@@ -40,7 +38,7 @@ where
 
                 if terminal.content.next().is_none() {
                     set_disable_input(true);
-                    complete_callback(true);
+                    complete_level_callback(true);
                 }
             }
             Err(_) => {

--- a/src/components/terminal.rs
+++ b/src/components/terminal.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 #[component]
 pub fn Terminal<F>(
     cx: Scope,
-    terminal: Signal<Level>,
+    terminal: Level,
     /// Callback used to signal when the terminal instance is completed
     complete_callback: F,
     #[prop(optional)] class: String,
@@ -17,7 +17,8 @@ where
     F: Fn(bool) + 'static,
 {
     // Variables
-    let title = move || terminal().content.create_title(cx);
+    let mut terminal = terminal;
+    let title = terminal.content.create_title(cx);
 
     // References
     let terminal_input_ref: NodeRef<Input> = create_node_ref(cx);
@@ -33,11 +34,11 @@ where
 
         let input = terminal_input_ref().expect("<input> to exist").value();
 
-        match terminal().content.check_answer(input.trim()) {
+        match terminal.content.check_answer(input.trim()) {
             Ok(output) => {
                 set_terminal_content.update(|content| content.push(output));
 
-                if terminal().content.next().is_none() {
+                if terminal.content.next().is_none() {
                     set_disable_input(true);
                     complete_callback(true);
                 }

--- a/src/components/terminal.rs
+++ b/src/components/terminal.rs
@@ -2,6 +2,9 @@ use crate::types::terminal_content::TerminalContent;
 use leptos::{ev::SubmitEvent, html::Input, *};
 use std::time::Duration;
 
+// TODO - Tech Debt: Find a way to not allow the whole 
+// component but rather the single closure
+#[allow(clippy::redundant_closure)]
 #[component]
 pub fn Terminal<F>(
     cx: Scope,
@@ -80,6 +83,7 @@ where
                                 class="outline-none bg-transparent"
                                 type="text"
                                 node_ref=terminal_input_ref
+                                // Closure not redundant - required for state updates
                                 disabled=move || disable_input()
                                 autofocus
                             />

--- a/src/components/tooltip.rs
+++ b/src/components/tooltip.rs
@@ -1,0 +1,21 @@
+use leptos::*;
+
+#[component]
+pub fn Tooltip(cx: Scope, children: Children, text: String) -> impl IntoView {
+    view! {
+        cx,
+        <span class="group relative w-max">
+            {children(cx)}
+            <span
+                class=format!("{} {} {}",
+                    "pointer-events-none absolute -top-7 left-0 w-max",
+                    "opacity-0 transition-opacity group-hover:opacity-100",
+                    "bg-pastel-green rounded p-2"
+                )
+            >
+                {text}
+            </span>
+        </span>
+        // </span>
+    }
+}

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -1,3 +1,4 @@
+use crate::components::instructions_panel::*;
 use crate::components::page_wrapper::*;
 use crate::components::terminal::*;
 use crate::types::terminal_content::TerminalContent;
@@ -7,12 +8,13 @@ use leptos::*;
 pub fn Home(cx: Scope) -> impl IntoView {
     // Signals
     let (complete, set_complete) = create_signal(cx, false);
+    let (level, set_level) = create_signal(cx, 0);
     // TODO - Temporary: Parse this from a file instead of hard-coding
     let terminal = TerminalContent::new("lesson-01_baby-steps", vec![
         (String::from("ls"), view! {cx, 
             <div>
                 <p><span class="text-pastel-blue">"❯ "</span>"ls"</p>
-                <div class="flex justify-around">
+                <div class="flex justify-around flex-wrap gap-2">
                     <span>"Waddle.duck"</span>
                     <span>"Ducky.duck"</span>
                     <span>"Pippin.duck"</span>
@@ -21,24 +23,74 @@ pub fn Home(cx: Scope) -> impl IntoView {
                 </div>
             </div>
         }.into_any()),
-        (String::from("help"), view! {cx, <p><span class="text-pastel-blue">"❯ "</span>"help"</p>}.into_any()),
     ]);
+
+    // Callbacks
+    let increment_level = move || {
+        set_level(level() + 1);
+    };
+
+    let decrement_level = move || {
+        if level() > 0 {
+            set_level(level() - 1);
+        }
+    };
 
     // Effects
     create_effect(cx, move |_| {
-        complete();
-        let _ = js_sys::eval(
-            "window.confetti({
+        if complete() {
+            let _ = js_sys::eval(
+                "window.confetti({
                     particleCount: 650,
                     spread: 100,
                     origin: { y: 0.6 }
                 });",
-        );
+            );
+        }
     });
 
     view! { cx,
         <PageWrapper>
-            <Terminal terminal={terminal} complete_callback={set_complete} />
+            <div class="flex flex-col md:flex-row justify-around gap-10">
+                <InstructionsPanel
+                    class=String::from("w-full md:w-1/3")
+                    increment_level_callback=increment_level
+                    decrement_level_callback=decrement_level
+                    level=level
+                >
+                    <div class="flex flex-col gap-5">
+                        <p>
+                            "Welcome to "<span class="text-pastel-yellow">"Quack"
+                            </span>" ‘n Hack, a game where you go through a series
+                            of challenges helping "<span class="text-pastel-yellow">
+                            "Quacky"</span>" find his friends."
+                        </p>
+                        <p>
+                            "To help find "<span class="text-pastel-yellow">"Quacky's"
+                            </span>" friends you’ll have to navigate the filesystem
+                            using "<span class="text-pastel-green">"Unix"</span>" 
+                            commands, along the way learning new tools."
+                        </p>
+                        <p>
+                            "Speaking of "<span class="text-pastel-yellow">"Quacky"
+                            </span>", where is he?"
+                        </p>
+                        <p>
+                            "The "<span class="text-pastel-purple">"`ls`"</span>
+                            " command will print all items in your current working
+                            "<span class="text-pastel-green">"directory"</span>" 
+                            in the terminal."</p>
+                        <p>
+                            "Try typing the command in the terminal to our right."
+                        </p>
+                    </div>
+                </InstructionsPanel>
+                <Terminal
+                    class=String::from("w-full md:w-2/3")
+                    terminal={terminal}
+                    complete_callback={set_complete}
+                />
+            </div>
         </PageWrapper>
     }
 }

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -37,7 +37,7 @@ pub fn Home(cx: Scope) -> impl IntoView {
         if complete() {
             let _ = js_sys::eval(
                 "window.confetti({
-                    particleCount: 650,
+                    particleCount: 500,
                     spread: 100,
                     origin: { y: 0.6 }
                 });",
@@ -56,12 +56,18 @@ pub fn Home(cx: Scope) -> impl IntoView {
                 >
                     {move || terminal().instructions}
                 </InstructionsPanel>
+
+                // This currently re-renders the whole component each time
+                // the terminal changes, not ideal.
+                //
+                // TODO - Tech Debt: Find a way to only re-render what's
+                // needed
                 {move ||
                     view! {cx,
                         <Terminal
                             class=String::from("w-full md:w-2/3")
                             terminal=terminal()
-                            complete_callback={set_complete}
+                            complete_level_callback={set_complete}
                         />
                     }}
             </div>

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -1,38 +1,34 @@
 use crate::components::instructions_panel::*;
 use crate::components::page_wrapper::*;
 use crate::components::terminal::*;
-use crate::types::terminal_content::TerminalContent;
+use crate::types::levels::Levels;
 use leptos::*;
 
 #[component]
 pub fn Home(cx: Scope) -> impl IntoView {
+    // Variables
+    let levels = Levels::init(cx);
+    let level_len = levels.levels.len() - 1;
+
     // Signals
     let (complete, set_complete) = create_signal(cx, false);
     let (level, set_level) = create_signal(cx, 0);
-    // TODO - Temporary: Parse this from a file instead of hard-coding
-    let terminal = TerminalContent::new("lesson-01_baby-steps", vec![
-        (String::from("ls"), view! {cx, 
-            <div>
-                <p><span class="text-pastel-blue">"❯ "</span>"ls"</p>
-                <div class="flex justify-around flex-wrap gap-2">
-                    <span>"Waddle.duck"</span>
-                    <span>"Ducky.duck"</span>
-                    <span>"Pippin.duck"</span>
-                    <a class="cursor-pointer"><span class="text-pastel-yellow">"Quacky.duck"</span></a>
-                    <span>"Bubbles.duck"</span>
-                </div>
-            </div>
-        }.into_any()),
-    ]);
+    let terminal = Signal::derive(cx, move || {
+        levels
+            .get_level(level())
+            .expect("there to always be a valid level")
+    });
 
     // Callbacks
     let increment_level = move || {
-        set_level(level() + 1);
+        if level() < level_len {
+            set_level.update(|n| *n += 1);
+        }
     };
 
     let decrement_level = move || {
         if level() > 0 {
-            set_level(level() - 1);
+            set_level.update(|n| *n -= 1);
         }
     };
 
@@ -54,36 +50,11 @@ pub fn Home(cx: Scope) -> impl IntoView {
             <div class="flex flex-col md:flex-row justify-around gap-10">
                 <InstructionsPanel
                     class=String::from("w-full md:w-1/3")
-                    increment_level_callback=increment_level
-                    decrement_level_callback=decrement_level
-                    level=level
+                    increment_level_callback={increment_level}
+                    decrement_level_callback={decrement_level}
+                    level={level}
                 >
-                    <div class="flex flex-col gap-5">
-                        <p>
-                            "Welcome to "<span class="text-pastel-yellow">"Quack"
-                            </span>" ‘n Hack, a game where you go through a series
-                            of challenges helping "<span class="text-pastel-yellow">
-                            "Quacky"</span>" find his friends."
-                        </p>
-                        <p>
-                            "To help find "<span class="text-pastel-yellow">"Quacky's"
-                            </span>" friends you’ll have to navigate the filesystem
-                            using "<span class="text-pastel-green">"Unix"</span>" 
-                            commands, along the way learning new tools."
-                        </p>
-                        <p>
-                            "Speaking of "<span class="text-pastel-yellow">"Quacky"
-                            </span>", where is he?"
-                        </p>
-                        <p>
-                            "The "<span class="text-pastel-purple">"`ls`"</span>
-                            " command will print all items in your current working
-                            "<span class="text-pastel-green">"directory"</span>" 
-                            in the terminal."</p>
-                        <p>
-                            "Try typing the command in the terminal to our right."
-                        </p>
-                    </div>
+                    {move || terminal().instructions}
                 </InstructionsPanel>
                 <Terminal
                     class=String::from("w-full md:w-2/3")

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -56,11 +56,14 @@ pub fn Home(cx: Scope) -> impl IntoView {
                 >
                     {move || terminal().instructions}
                 </InstructionsPanel>
-                <Terminal
-                    class=String::from("w-full md:w-2/3")
-                    terminal={terminal}
-                    complete_callback={set_complete}
-                />
+                {move ||
+                    view! {cx,
+                        <Terminal
+                            class=String::from("w-full md:w-2/3")
+                            terminal=terminal()
+                            complete_callback={set_complete}
+                        />
+                    }}
             </div>
         </PageWrapper>
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,1 +1,3 @@
+pub mod level;
+pub mod levels;
 pub mod terminal_content;

--- a/src/types/level.rs
+++ b/src/types/level.rs
@@ -1,0 +1,8 @@
+use super::terminal_content::TerminalContent;
+use leptos::{html::AnyElement, HtmlElement};
+
+#[derive(Clone)]
+pub struct Level {
+    pub content: TerminalContent,
+    pub instructions: HtmlElement<AnyElement>,
+}

--- a/src/types/levels.rs
+++ b/src/types/levels.rs
@@ -74,9 +74,14 @@ impl Levels {
                                     </div>
                                 </div>
                             }.into_any()),
-                            (String::from("cat"), view! {cx, 
+                            (String::from("cat Quacky.duck"), view! {cx, 
                                 <div>
-                                    <p><span class="text-pastel-blue">"❯ "</span>"cat"</p>
+                                    <p><span class="text-pastel-blue">"❯ "</span>"cat "<span class="text-pastel-yellow">"Quacky.duck"</span></p>
+                                    <pre class="text-pastel-yellow">r#"
+                                             _
+                                          __(.)<
+                                      ... \___)
+                                    "#</pre>
                                 </div>
                             }.into_any()),
                         ]
@@ -94,9 +99,6 @@ impl Levels {
     }
 
     pub fn get_level(&self, level: usize) -> Option<Level> {
-        match self.levels.get(level) {
-            Some(content) => Some(content.clone()),
-            None => None,
-        }
+        self.levels.get(level).cloned()
     }
 }

--- a/src/types/levels.rs
+++ b/src/types/levels.rs
@@ -1,0 +1,102 @@
+use super::level::Level;
+use super::terminal_content::TerminalContent;
+use leptos::{view, Scope};
+
+pub struct Levels {
+    pub levels: Vec<Level>,
+}
+
+impl Levels {
+    pub fn init(cx: Scope) -> Levels {
+        Self {
+            levels:vec![
+                Level {
+                    content: TerminalContent::new(
+                        "lesson-01_baby-steps", 
+                        vec![
+                            (String::from("ls"), view! {cx, 
+                                <div>
+                                    <p><span class="text-pastel-blue">"❯ "</span>"ls"</p>
+                                    <div class="flex justify-around flex-wrap gap-2">
+                                        <span>"Waddle.duck"</span>
+                                        <span>"Ducky.duck"</span>
+                                        <span>"Pippin.duck"</span>
+                                        <a class="cursor-pointer"><span class="text-pastel-yellow">"Quacky.duck"</span></a>
+                                        <span>"Bubbles.duck"</span>
+                                    </div>
+                                </div>
+                            }.into_any()),
+                        ]
+                    ),
+                    instructions: view! {cx,
+                        <div class="flex flex-col gap-5">
+                            <p>
+                                "Welcome to "<span class="text-pastel-yellow">"Quack"
+                                </span>" ‘n Hack, a game where you go through a series
+                                of challenges helping "<span class="text-pastel-yellow">
+                                "Quacky"</span>" find his friends."
+                            </p>
+                            <p>
+                                "To help find "<span class="text-pastel-yellow">"Quacky's"
+                                </span>" friends you’ll have to navigate the filesystem
+                                using "<span class="text-pastel-green">"Unix"</span>" 
+                                commands, along the way learning new tools."
+                            </p>
+                            <p>
+                                "Speaking of "<span class="text-pastel-yellow">"Quacky"
+                                </span>", where is he?"
+                            </p>
+                            <p>
+                                "The "<span class="text-pastel-purple">"`ls`"</span>
+                                " command will print all items in your current working
+                                "<span class="text-pastel-green">"directory"</span>" 
+                                in the terminal."</p>
+                            <p>
+                                "Try typing the command in the terminal to our right."
+                            </p>
+                        </div>
+                    }.into_any()
+                },
+
+                Level {
+                    content: TerminalContent::new(
+                        "lesson-02_cats", 
+                        vec![
+                            (String::from("ls"), view! {cx, 
+                                <div>
+                                    <p><span class="text-pastel-blue">"❯ "</span>"ls"</p>
+                                    <div class="flex justify-around flex-wrap gap-2">
+                                        <span>"Waddle.duck"</span>
+                                        <span>"Ducky.duck"</span>
+                                        <span>"Pippin.duck"</span>
+                                        <a class="cursor-pointer"><span class="text-pastel-yellow">"Quacky.duck"</span></a>
+                                        <span>"Bubbles.duck"</span>
+                                    </div>
+                                </div>
+                            }.into_any()),
+                            (String::from("cat"), view! {cx, 
+                                <div>
+                                    <p><span class="text-pastel-blue">"❯ "</span>"cat"</p>
+                                </div>
+                            }.into_any()),
+                        ]
+                    ),
+                    instructions: view! {cx,
+                        <div class="flex flex-col gap-5">
+                            <p>
+                                "Cats?"
+                            </p>
+                        </div>
+                    }.into_any()
+                }
+            ]
+        }
+    }
+
+    pub fn get_level(&self, level: usize) -> Option<Level> {
+        match self.levels.get(level) {
+            Some(content) => Some(content.clone()),
+            None => None,
+        }
+    }
+}

--- a/src/types/terminal_content.rs
+++ b/src/types/terminal_content.rs
@@ -2,7 +2,7 @@ use crate::{html::AnyElement, view, HtmlElement, IntoView, Scope};
 
 #[derive(Clone)]
 pub struct TerminalContent {
-    pub progress: usize,
+    progress: usize,
     pub title: String,
     pub answers: Vec<(String, HtmlElement<AnyElement>)>,
 }
@@ -47,6 +47,6 @@ impl TerminalContent {
     }
 
     pub fn check_finished(&self) -> bool {
-        self.progress == self.answers.len()
+        self.progress == self.answers.len() - 1
     }
 }

--- a/style/output.css
+++ b/style/output.css
@@ -516,17 +516,33 @@ video {
   --tw-backdrop-sepia:  ;
 }
 
+.pointer-events-none {
+  pointer-events: none;
+}
+
 .static {
   position: static;
+}
+
+.absolute {
+  position: absolute;
+}
+
+.relative {
+  position: relative;
+}
+
+.-top-7 {
+  top: -1.75rem;
+}
+
+.left-0 {
+  left: 0px;
 }
 
 .mx-auto {
   margin-left: auto;
   margin-right: auto;
-}
-
-.mb-10 {
-  margin-bottom: 2.5rem;
 }
 
 .mt-3 {
@@ -549,12 +565,29 @@ video {
   height: 24rem;
 }
 
-.h-screen {
-  height: 100vh;
+.h-\[30rem\] {
+  height: 30rem;
+}
+
+.h-full {
+  height: 100%;
+}
+
+.min-h-screen {
+  min-height: 100vh;
+}
+
+.w-7 {
+  width: 1.75rem;
 }
 
 .w-full {
   width: 100%;
+}
+
+.w-max {
+  width: -moz-max-content;
+  width: max-content;
 }
 
 @keyframes shake {
@@ -591,12 +624,48 @@ video {
   cursor: pointer;
 }
 
+.flex-row {
+  flex-direction: row;
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}
+
 .justify-around {
   justify-content: space-around;
 }
 
+.gap-10 {
+  gap: 2.5rem;
+}
+
+.gap-2 {
+  gap: 0.5rem;
+}
+
+.gap-5 {
+  gap: 1.25rem;
+}
+
 .overflow-scroll {
   overflow: scroll;
+}
+
+.rounded {
+  border-radius: 0.25rem;
 }
 
 .border-2 {
@@ -613,6 +682,11 @@ video {
   background-color: rgb(31 31 31 / var(--tw-bg-opacity));
 }
 
+.bg-pastel-green {
+  --tw-bg-opacity: 1;
+  background-color: rgb(162 217 177 / var(--tw-bg-opacity));
+}
+
 .bg-terminal-dark-blue {
   --tw-bg-opacity: 1;
   background-color: rgb(30 30 46 / var(--tw-bg-opacity));
@@ -627,9 +701,31 @@ video {
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
 }
 
+.fill-white {
+  fill: #fff;
+}
+
+.p-2 {
+  padding: 0.5rem;
+}
+
+.p-5 {
+  padding: 1.25rem;
+}
+
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
 .px-5 {
   padding-left: 1.25rem;
   padding-right: 1.25rem;
+}
+
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
 }
 
 .py-5 {
@@ -637,8 +733,12 @@ video {
   padding-bottom: 1.25rem;
 }
 
-.pt-20 {
-  padding-top: 5rem;
+.pb-10 {
+  padding-bottom: 2.5rem;
+}
+
+.pt-5 {
+  padding-top: 1.25rem;
 }
 
 .text-2xl {
@@ -651,6 +751,16 @@ video {
   color: rgb(178 216 216 / var(--tw-text-opacity));
 }
 
+.text-pastel-green {
+  --tw-text-opacity: 1;
+  color: rgb(162 217 177 / var(--tw-text-opacity));
+}
+
+.text-pastel-purple {
+  --tw-text-opacity: 1;
+  color: rgb(213 190 232 / var(--tw-text-opacity));
+}
+
 .text-pastel-yellow {
   --tw-text-opacity: 1;
   color: rgb(255 248 165 / var(--tw-text-opacity));
@@ -659,6 +769,10 @@ video {
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.opacity-0 {
+  opacity: 0;
 }
 
 .opacity-20 {
@@ -670,9 +784,41 @@ video {
   outline-offset: 2px;
 }
 
+.transition-opacity {
+  transition-property: opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.group:hover .group-hover\:opacity-100 {
+  opacity: 1;
+}
+
+@media (min-width: 768px) {
+  .md\:h-\[30rem\] {
+    height: 30rem;
+  }
+
+  .md\:w-1\/3 {
+    width: 33.333333%;
+  }
+
+  .md\:w-2\/3 {
+    width: 66.666667%;
+  }
+
+  .md\:flex-row {
+    flex-direction: row;
+  }
+
+  .md\:pt-20 {
+    padding-top: 5rem;
+  }
+}
+
 @media (min-width: 1024px) {
   .lg\:max-w-content {
-    max-width: 1080px;
+    max-width: 1280px;
   }
 
   .lg\:max-w-header {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,7 +17,7 @@ module.exports = {
             },
             maxWidth: {
                 "header": "1920px",
-                "content": "1080px",
+                "content": "1280px",
             },
             keyframes: {
                 shake: {


### PR DESCRIPTION
## Changes
- Added `InstructionsPanel` component
- Added `Tooltip` component
- Added `Level` struct to hold `TerminalContent` and `InstructionsPanel` content
- Added `Levels` struct to hold all level data and provided a function to get a level
- Fixed bug where user could keep entering input in terminal even though the level had ended
- Added mock first level
- Added ability to swap between levels
- Added `class` prop to components to allow style overrides

## Images
<img width="1476" alt="image" src="https://github.com/BrookJeynes/quack-n-hack/assets/25432120/2b6ce5e3-902e-475b-8b4e-f01c70ff60fb">

**Figure: New instructions component on the left**